### PR TITLE
Modify sms.text column type to support LMS (#14)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{ $dist->name }}
 
 {{ $NEXT }}
+    - Modify sms.text column type to support LMS (#14)
 
 0.005     2015-02-08 17:37:00+09:00 Asia/Seoul
     - Add column: order.message (#12)

--- a/db/init.sql
+++ b/db/init.sql
@@ -390,7 +390,7 @@ CREATE TABLE `sms` (
 
   `from`        VARCHAR(12)  NOT NULL,
   `to`          VARCHAR(12)  NOT NULL,
-  `text`        VARCHAR(256) NOT NULL,
+  `text`        TEXT         NOT NULL,
 
   `ret`         INT          DEFAULT NULL,
   `status`      VARCHAR(7)   DEFAULT 'pending',

--- a/lib/OpenCloset/Schema/Result/SMS.pm
+++ b/lib/OpenCloset/Schema/Result/SMS.pm
@@ -49,9 +49,8 @@ __PACKAGE__->table("sms");
 
 =head2 text
 
-  data_type: 'varchar'
+  data_type: 'text'
   is_nullable: 0
-  size: 256
 
 =head2 ret
 
@@ -95,7 +94,7 @@ __PACKAGE__->add_columns(
     "to",
     { data_type => "varchar", is_nullable => 0, size => 12 },
     "text",
-    { data_type => "varchar", is_nullable => 0, size => 256 },
+    { data_type => "text", is_nullable => 0 },
     "ret",
     { data_type => "integer", is_nullable => 1 },
     "status",
@@ -134,8 +133,8 @@ __PACKAGE__->add_columns(
 
 __PACKAGE__->set_primary_key("id");
 
-# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-02-06 19:37:57
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:+Awn15kcC/UlOw8JiMpSig
+# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-02-12 16:44:10
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:SWEOgqOWExWUf3XRxP4s5A
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 


### PR DESCRIPTION
SMS 기준으로 스키마를 작성했기 때문에 불필요하게 컬럼이 길 필요가
없어 256 크기로 했었습니다만, 이제는 LMS를 지원해야 하기 때문에
TEXT 형태로 수정합니다. LMS는 국내에서 euc-kr 인코딩 기준 2000
바이트로 고정되어 있지만 유니코드일 경우 바이트 수가 다르므로
길이 제한은 소프트웨어적으로 처리합니다.

기존 데이터베이스에는 다음 질의를 적용해야 합니다.

> ALTER TABLE `sms`  CHANGE COLUMN `text` `text` TEXT NOT NULL ;

dbicdump를 이용해서 라이브러리를 갱신합니다.

> OPENCLOSET_CONFIG=.../app.conf dbicdump -Ilib db/schema-loader.pl
