### PR TITLE
Prefetch 'status' table to increase speed

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{ $dist->name }}
 
 {{ $NEXT }}
+    - Order.analyze_order_status_logs(): prefetch status for speed (#20)
 
 0.008     2015-02-16 17:12:36+09:00 Asia/Seoul
     - Add user_info.wearon_date & order.wearon_date (#18)
@@ -17,7 +18,7 @@ Revision history for {{ $dist->name }}
 0.004     2015-02-06 23:08:14+09:00 Asia/Seoul
     - Use OpenCloset::Config when loading config file (#6)
     - Support perltidy, perlcritic and tidyall with dbicdump (#10)
-    - Add analyze_order_status_log() method in order resultset (#8)
+    - Add analyze_order_status_logs() method in order resultset (#8)
 
 0.003     2015-01-29 18:37:11+09:00 Asia/Seoul
     - Add foreign key with cascade: order_status_log.order_id  -> order.id

--- a/lib/OpenCloset/Schema/Result/Order.pm
+++ b/lib/OpenCloset/Schema/Result/Order.pm
@@ -628,7 +628,8 @@ sub analyze_order_status_logs {
     my $self = shift;
 
     my @status_logs =
-        $self->order_status_logs( {}, { order_by => { -asc => 'timestamp' } } );
+        $self->order_status_logs( {},
+        { order_by => { -asc => 'timestamp' }, prefetch => 'status' } );
 
     my @logs;
     my %elapsed_time;

--- a/lib/OpenCloset/Schema/Result/Order.pm
+++ b/lib/OpenCloset/Schema/Result/Order.pm
@@ -627,9 +627,13 @@ sub _normalize_status_name {
 sub analyze_order_status_logs {
     my $self = shift;
 
-    my @status_logs =
-        $self->order_status_logs( {},
-        { order_by => { -asc => 'timestamp' }, prefetch => 'status' } );
+    my @status_logs = $self->order_status_logs(
+        {},
+        {
+            order_by => { -asc => 'timestamp' },
+            prefetch => 'status',
+        },
+    );
 
     my @logs;
     my %elapsed_time;


### PR DESCRIPTION
analyze_order_status_logs 함수는 상태에 대한 이름을 알기위해서
status->name에 접근하기때문에 성능의 저하가 발생합니다. DBIC에서
제공하는 'prefetch' 속성을 이용하면 해당 테이블에 접근할때 추가쿼리가
발생하지 않도록 미리 지정된 테이블이 값을 저장하기 때문에 DB로 보내는
쿼리를 줄일수 있습니다.
