### PR TITLE
Feature/#24 sms support apistore

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{ $dist->name }}
 
 {{ $NEXT }}
+    - Add sms.method to support various sms sending module (#24)
 
 0.010     2015-03-10 16:37:21+09:00 Asia/Seoul
     - Add '사이즈없음' status (#23)

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{ $dist->name }}
 
 {{ $NEXT }}
+    - Add sms.detail to save result of sms sending (#24)
     - Add sms.method to support various sms sending module (#24)
 
 0.010     2015-03-10 16:37:21+09:00 Asia/Seoul

--- a/db/init.sql
+++ b/db/init.sql
@@ -401,6 +401,7 @@ CREATE TABLE `sms` (
 
   `ret`         INT          DEFAULT NULL,
   `status`      VARCHAR(7)   DEFAULT 'pending',
+  `method`      VARCHAR(128) DEFAULT NULL,
   `sent_date`   DATETIME     DEFAULT NULL,
   `create_date` DATETIME     DEFAULT NULL,
 

--- a/lib/OpenCloset/Schema/Result/SMS.pm
+++ b/lib/OpenCloset/Schema/Result/SMS.pm
@@ -70,6 +70,11 @@ __PACKAGE__->table("sms");
   is_nullable: 1
   size: 128
 
+=head2 detail
+
+  data_type: 'text'
+  is_nullable: 1
+
 =head2 sent_date
 
   data_type: 'datetime'
@@ -112,6 +117,8 @@ __PACKAGE__->add_columns(
     },
     "method",
     { data_type => "varchar", is_nullable => 1, size => 128 },
+    "detail",
+    { data_type => "text", is_nullable => 1 },
     "sent_date",
     {
         data_type                 => "datetime",
@@ -142,8 +149,8 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("id");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-06-17 20:39:42
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:eskbnWJ/eHW9TNqtcWgLgg
+# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-06-17 21:53:28
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:9kR3GYsSdfKk5pSv8Yuqhg
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 

--- a/lib/OpenCloset/Schema/Result/SMS.pm
+++ b/lib/OpenCloset/Schema/Result/SMS.pm
@@ -64,6 +64,12 @@ __PACKAGE__->table("sms");
   is_nullable: 1
   size: 7
 
+=head2 method
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 128
+
 =head2 sent_date
 
   data_type: 'datetime'
@@ -104,6 +110,8 @@ __PACKAGE__->add_columns(
         is_nullable   => 1,
         size          => 7,
     },
+    "method",
+    { data_type => "varchar", is_nullable => 1, size => 128 },
     "sent_date",
     {
         data_type                 => "datetime",
@@ -133,8 +141,9 @@ __PACKAGE__->add_columns(
 
 __PACKAGE__->set_primary_key("id");
 
-# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-02-12 16:44:10
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:SWEOgqOWExWUf3XRxP4s5A
+
+# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-06-17 20:39:42
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:eskbnWJ/eHW9TNqtcWgLgg
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 


### PR DESCRIPTION
데이터베이스 큐에 쌓이는 전송해야 할 각각의 문자 메시지 건에 대해 어떤 방식으로 전송하는지를 저장할 수 있는 컬럼과 전송 결과를 확인할 때 필요한 정보를 저장할 수 있는 컬럼을 추가합니다.
- `sms.method`
- `sms.detail`

기존 데이터베이스에는 다음 질의를 적용합니다.

``` sql
ALTER TABLE `sms` ADD COLUMN `method` VARCHAR(128) NULL DEFAULT NULL AFTER `status`;
UPDATE `sms` SET `method`='SMS::Send::KR::CoolSMS';
ALTER TABLE `sms` ADD COLUMN `detail` TEXT NULL DEFAULT NULL AFTER `method`;
```
