### PR TITLE
Add $since and $timezone arguments for rentable_duration()

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Revision history for {{ $dist->name }}
 
 {{ $NEXT }}
+    - 의류 대여 가능일 계산이 정확하지 않음 (#74)
+        - clothes.rented_duration()
+        - clothes.rentable_duration()
+        - clothes.rent_ratio()
 
 0.035     2016-05-26 18:05:37+09:00 Asia/Seoul
     - Add column: order.ignore (#78)

--- a/lib/OpenCloset/Schema/Result/Clothes.pm
+++ b/lib/OpenCloset/Schema/Result/Clothes.pm
@@ -484,19 +484,22 @@ __PACKAGE__->many_to_many( "orders", "order_details", "order" );
 =cut
 
 sub warehousing_date {
-    my ( $self, $base_dt ) = @_;
+    my ( $self, $time_zone, $base_dt ) = @_;
 
     #
     # 입고일: 기증 행위가 생성된 날짜
     #
     my $warehousing_dt = $self->donation->create_date->clone;
-    $warehousing_dt->set_time_zone("Asia/Seoul");
 
     #
     # 기존 시점 이전에 입고된 의류의 경우
     # 입고일을 기준 시점으로 함
     #
-    $warehousing_dt = $base_dt if $warehousing_dt < $base_dt;
+    if ($base_dt) {
+        $warehousing_dt = $base_dt if $warehousing_dt < $base_dt;
+    }
+
+    $warehousing_dt->set_time_zone($time_zone) if $time_zone;
 
     return $warehousing_dt;
 }

--- a/lib/OpenCloset/Schema/Result/Clothes.pm
+++ b/lib/OpenCloset/Schema/Result/Clothes.pm
@@ -484,18 +484,13 @@ __PACKAGE__->many_to_many( "orders", "order_details", "order" );
 =cut
 
 sub warehousing_date {
-    my ( $self, $since ) = @_;
+    my ( $self, $base_dt ) = @_;
 
     #
     # 입고일: 기증 행위가 생성된 날짜
     #
     my $warehousing_dt = $self->donation->create_date->clone;
     $warehousing_dt->set_time_zone("Asia/Seoul");
-
-    #
-    # 기준 시점: 인자로 받은 시점
-    #
-    my $base_dt = DateTime->new(%$since);
 
     #
     # 기존 시점 이전에 입고된 의류의 경우

--- a/lib/OpenCloset/Schema/Result/Clothes.pm
+++ b/lib/OpenCloset/Schema/Result/Clothes.pm
@@ -484,7 +484,7 @@ __PACKAGE__->many_to_many( "orders", "order_details", "order" );
 =cut
 
 sub warehousing_date {
-    my ( $self, $time_zone, $base_dt ) = @_;
+    my ( $self, $time_zone, $fixed_warehousing_dt ) = @_;
 
     #
     # 입고일: 기증 행위가 생성된 날짜
@@ -495,8 +495,8 @@ sub warehousing_date {
     # 기존 시점 이전에 입고된 의류의 경우
     # 입고일을 기준 시점으로 함
     #
-    if ($base_dt) {
-        $warehousing_dt = $base_dt if $warehousing_dt < $base_dt;
+    if ($fixed_warehousing_dt) {
+        $warehousing_dt = $fixed_warehousing_dt if $warehousing_dt < $fixed_warehousing_dt;
     }
 
     $warehousing_dt->set_time_zone($time_zone) if $time_zone;

--- a/lib/OpenCloset/Schema/Result/Clothes.pm
+++ b/lib/OpenCloset/Schema/Result/Clothes.pm
@@ -507,15 +507,15 @@ sub warehousing_date {
 =method rentable_duration
 
 의류의 입고일로부터 오늘까지의 날 수를 반환합니다.
-첫번째 인자는 기준시점입니다.
-두번째 인자는 현재를 계산할때 적용할 타임존입니다.
-의류의 입고시점이 기준시점보다 이전인경우 기준시점으로 계산합니다.
-입고일이 오늘보다 앞설경우 음수를 반환합니다.
+첫 번째 인자는 시간 계산시 기준으로 삼을 시간대입니다.
+두 번째 인자는 최소 의류 입고일입니다.
+의류의 입고 시점이 최소 의류 입고일보다 이전인 경우 최소 의류 입고일을
+의류 입고일로 간주합니다. 입고일이 오늘보다 이를 경우 음수를 반환합니다.
 
 =cut
 
 sub rentable_duration {
-    my ( $self, $fixed_warehousing_dt, $time_zone ) = @_;
+    my ( $self, $time_zone, $fixed_warehousing_dt ) = @_;
 
     my $warehousing_dt = $self->warehousing_date( $time_zone, $fixed_warehousing_dt );
     return unless $warehousing_dt;

--- a/lib/OpenCloset/Schema/Result/Clothes.pm
+++ b/lib/OpenCloset/Schema/Result/Clothes.pm
@@ -478,8 +478,8 @@ __PACKAGE__->many_to_many( "orders", "order_details", "order" );
 
 =method warehousing_date
 
-의류의 입고일을 반환합니다.인자로 받은 기준시점 이전에 입고된 의류의 경우
-기준시점을 입고일로 반환합니다.
+의류의 입고일을 반환합니다. 인자로 받은 기준 시점 이전에 입고된 의류의 경우
+기준 시점을 입고일로 반환합니다.
 
 =cut
 

--- a/lib/OpenCloset/Schema/Result/Clothes.pm
+++ b/lib/OpenCloset/Schema/Result/Clothes.pm
@@ -520,7 +520,9 @@ sub rentable_duration {
     my $warehousing_dt = $self->warehousing_date( $time_zone, $fixed_warehousing_dt );
     return unless $warehousing_dt;
 
-    my $now_dt = DateTime->now( time_zone => $time_zone );
+    my $now_dt = DateTime->now;
+    $not_dt->set_time_zone($time_zone) if $time_zone;
+
     my $delta = $warehousing_dt->delta_days($now_dt)->in_units("days");
 
     #

--- a/lib/OpenCloset/Schema/Result/Clothes.pm
+++ b/lib/OpenCloset/Schema/Result/Clothes.pm
@@ -515,12 +515,12 @@ sub warehousing_date {
 =cut
 
 sub rentable_duration {
-    my ( $self, $since, $tz ) = @_;
+    my ( $self, $since, $time_zone ) = @_;
 
     my $base_dt = $self->warehousing_date($since);
     return unless $base_dt;
 
-    my $now_dt = DateTime->now( time_zone => $tz );
+    my $now_dt = DateTime->now( time_zone => $time_zone );
     my $delta = $base_dt->delta_days($now_dt)->in_units("days");
 
     #

--- a/lib/OpenCloset/Schema/Result/Clothes.pm
+++ b/lib/OpenCloset/Schema/Result/Clothes.pm
@@ -515,18 +515,18 @@ sub warehousing_date {
 =cut
 
 sub rentable_duration {
-    my ( $self, $since, $time_zone ) = @_;
+    my ( $self, $fixed_warehousing_dt, $time_zone ) = @_;
 
-    my $base_dt = $self->warehousing_date($since);
-    return unless $base_dt;
+    my $warehousing_dt = $self->warehousing_date( $time_zone, $fixed_warehousing_dt );
+    return unless $warehousing_dt;
 
     my $now_dt = DateTime->now( time_zone => $time_zone );
-    my $delta = $base_dt->delta_days($now_dt)->in_units("days");
+    my $delta = $warehousing_dt->delta_days($now_dt)->in_units("days");
 
     #
     # 입고일이 오늘보다 앞설경우 음수를 반환합니다.
     #
-    $delta = $delta * -1 if $base_dt > $now_dt;
+    $delta = $delta * -1 if $warehousing_dt > $now_dt;
 
     return $delta;
 }

--- a/lib/OpenCloset/Schema/Result/Clothes.pm
+++ b/lib/OpenCloset/Schema/Result/Clothes.pm
@@ -581,16 +581,16 @@ sub rented_duration {
 
 =method rent_ratio
 
-대여가능일과 대여일의 비율을 돌려숩니다.
-첫번째 인자는 기준시점입니다.
-두번째 인자는 현재를 계산할때 적용할 타임존입니다.
+의류의 입고일로부터 기준 날짜까지의 날을 기준으로 대여가능일과 대여일의 비율을 돌려줍니다.
+첫 번째 인자는 시간 계산시 기준 날짜 DateTime 객체입니다.
+두 번째 인자는 최소 의류 입고일입니다.
 
 =cut
 
 sub rent_ratio {
-    my ( $self, $since, $timezone ) = @_;
+    my ( $self, $dest_dt, $min_warehousing_dt ) = @_;
 
-    my $rentable = $self->rentable_duration($since, $timezone);
+    my $rentable = $self->rentable_duration( $dest_dt, $min_warehousing_dt );
     return 0 unless $rentable;
 
     return $self->rented_duration / $rentable;

--- a/t/gh-074-remove-hardcoded-arguments.t
+++ b/t/gh-074-remove-hardcoded-arguments.t
@@ -4,7 +4,14 @@ use strict;
 use warnings;
 use DateTime;
 
-my $now = DateTime->now( time_zone => "Asia/Seoul" );
+my $time_zone       = "Asia/Seoul";
+my $now_dt          = DateTime->now( time_zone => $time_zone );
+my $system_start_dt = DateTime->new(
+    year      => 2014,
+    month     => 12,
+    day       => 17,
+    time_zone => $time_zone,
+);
 
 use Test::DBIx::Class {
     schema_class => "OpenCloset::Schema",
@@ -17,10 +24,10 @@ use Test::DBIx::Class {
 fixtures_ok [
     Donation => [
         [qw/id user_id create_date/],
-        [ 1, 1, $now->clone->add( days => -30 )->ymd ],
-        [ 2, 1, $now->clone->add( days => -30 )->ymd ],
-        [ 3, 1, $now->clone->add( days => -30 )->ymd ],
-        [ 4, 1, $now->clone->add( days => 8 )->ymd ],
+        [ 1, 1, $now_dt->clone->add( days => -30 )->ymd ],
+        [ 2, 1, $now_dt->clone->add( days => -30 )->ymd ],
+        [ 3, 1, $now_dt->clone->add( days => -30 )->ymd ],
+        [ 4, 1, $now_dt->clone->add( days => 8 )->ymd ],
     ],
     Order => [
         [qw/id user_id rental_date return_date/],
@@ -30,7 +37,6 @@ fixtures_ok [
         , # 정상적인 경우(2일후 반납)
         [ 14977, 22623, '2015-10-27 15:12:00', '2015-10-27 19:00:00' ]
         , # 정상적인 경우(당일 반납)
-
         [ 14978, 22622, '2015-10-27 09:45:00', '2015-10-29 12:03:29' ]
         , # 정상적인 경우(2일후 반납)
     ],
@@ -51,13 +57,6 @@ fixtures_ok [
     ],
     'Installed fixtures';
 
-my $system_start_date = {
-    year      => 2014,
-    month     => 12,
-    day       => 17,
-    time_zone => 'Asia/Seoul',
-};
-
 ## Your testing code below ##
 
 subtest "clothes.rent_ratio(): normal donation, earlier return than rent(abnormal)",
@@ -67,7 +66,7 @@ subtest "clothes.rent_ratio(): normal donation, earlier return than rent(abnorma
     my $tz         = "Asia/Seoul";
     ok my $clothes = Clothes->find( { code => $code } ) => "find clothes";
     is $clothes->code, $code => "clothes.code";
-    my $ratio = $clothes->rent_ratio( $system_start_date, $tz );
+    my $ratio = $clothes->rent_ratio( $now_dt, $system_start_dt );
 
     is $ratio, $rent_ratio => "clothes.rent_ratio";
     };
@@ -80,10 +79,10 @@ subtest "clothes.rent_ratio(): normal donation, two days after return", sub {
     my $rent_ratio        = 0.1;
     ok my $clothes = Clothes->find( { code => $code } ) => "find clothes";
     is $clothes->code, $code => "clothes.code";
-    is $clothes->rentable_duration( $system_start_date, $tz ),
+    is $clothes->rentable_duration( $now_dt, $system_start_dt ),
         $rentable_duration => "clothes.rentable_duration";
     is $clothes->rented_duration, $rented_duration => "clothes.rented_duration";
-    is $clothes->rent_ratio( $system_start_date, $tz ),
+    is $clothes->rent_ratio( $now_dt, $system_start_dt ),
         $rent_ratio => "clothes.rent_ratio";
 };
 
@@ -95,10 +94,10 @@ subtest "clothes.rent_ratio(): normal donation, immediately return", sub {
     my $rent_ratio        = 0.0333333333333333;
     ok my $clothes = Clothes->find( { code => $code } ) => "find clothes";
     is $clothes->code, $code => "clothes.code";
-    is $clothes->rentable_duration( $system_start_date, $tz ),
+    is $clothes->rentable_duration( $now_dt, $system_start_dt ),
         $rentable_duration => "clothes.rentable_duration";
     is $clothes->rented_duration, $rented_duration => "clothes.rented_duration";
-    is $clothes->rent_ratio( $system_start_date, $tz ),
+    is $clothes->rent_ratio( $now_dt, $system_start_dt ),
         $rent_ratio => "clothes.rent_ratio";
 };
 
@@ -110,10 +109,10 @@ subtest "clothes.rent_ratio(): abnormal donation, normal return", sub {
     my $rent_ratio        = -0.375;
     ok my $clothes = Clothes->find( { code => $code } ) => "find clothes";
     is $clothes->code, $code => "clothes.code";
-    is $clothes->rentable_duration( $system_start_date, $tz ),
+    is $clothes->rentable_duration( $now_dt, $system_start_dt ),
         $rentable_duration => "clothes.rentable_duration";
     is $clothes->rented_duration, $rented_duration => "clothes.rented_duration";
-    is $clothes->rent_ratio( $system_start_date, $tz ),
+    is $clothes->rent_ratio( $now_dt, $system_start_dt ),
         $rent_ratio => "clothes.rent_ratio";
 };
 

--- a/t/gh-074-remove-hardcoded-arguments.t
+++ b/t/gh-074-remove-hardcoded-arguments.t
@@ -1,0 +1,122 @@
+use Test::More;
+
+use strict;
+use warnings;
+use DateTime;
+
+my $now = DateTime->now( time_zone => "Asia/Seoul" );
+
+use Test::DBIx::Class {
+    schema_class => "OpenCloset::Schema",
+    connect_info => [ "dbi:SQLite:dbname=:memory:", "", "" ],
+    connect_opts  => { quote_char => q{`}, },
+    fixture_class => "::Populate",
+    },
+    "Donation", "Clothes";
+
+fixtures_ok [
+    Donation => [
+        [qw/id user_id create_date/],
+        [ 1, 1, $now->clone->add( days => -30 )->ymd ],
+        [ 2, 1, $now->clone->add( days => -30 )->ymd ],
+        [ 3, 1, $now->clone->add( days => -30 )->ymd ],
+        [ 4, 1, $now->clone->add( days => 8 )->ymd ],
+    ],
+    Order => [
+        [qw/id user_id rental_date return_date/],
+        [ 14975, 22621, '2015-10-22 11:23:00', '2015-10-20 12:03:29' ]
+        , # 대여일보다 반납일이 이른경우
+        [ 14976, 22622, '2015-10-27 09:45:00', '2015-10-29 12:03:29' ]
+        , # 정상적인 경우(2일후 반납)
+        [ 14977, 22623, '2015-10-27 15:12:00', '2015-10-27 19:00:00' ]
+        , # 정상적인 경우(당일 반납)
+
+        [ 14978, 22622, '2015-10-27 09:45:00', '2015-10-29 12:03:29' ]
+        , # 정상적인 경우(2일후 반납)
+    ],
+    OrderDetail => [
+        [qw/id name order_id clothes_code/],
+        [ 86524, '자켓', 14975, '0J0H1' ],
+        [ 86525, '자켓', 14976, '0J0H2' ],
+        [ 86526, '자켓', 14977, '0J0H3' ],
+        [ 86527, '자켓', 14978, '0J0H4' ],
+    ],
+    Clothes => [
+        [qw/id code donation_id category/],
+        [ 6343, '0J0H1', 1, 'jacket' ],
+        [ 6344, '0J0H2', 2, 'jacket' ],
+        [ 6345, '0J0H3', 3, 'jacket' ],
+        [ 6346, '0J0H4', 4, 'jacket' ],
+    ],
+    ],
+    'Installed fixtures';
+
+my $system_start_date = {
+    year      => 2014,
+    month     => 12,
+    day       => 17,
+    time_zone => 'Asia/Seoul',
+};
+
+## Your testing code below ##
+
+subtest "clothes.rent_ratio(): normal donation, earlier return than rent(abnormal)",
+    sub {
+    my $code       = "0J0H1";
+    my $rent_ratio = 0;
+    my $tz         = "Asia/Seoul";
+    ok my $clothes = Clothes->find( { code => $code } ) => "find clothes";
+    is $clothes->code, $code => "clothes.code";
+    my $ratio = $clothes->rent_ratio( $system_start_date, $tz );
+
+    is $ratio, $rent_ratio => "clothes.rent_ratio";
+    };
+
+subtest "clothes.rent_ratio(): normal donation, two days after return", sub {
+    my $code              = "0J0H2";
+    my $tz                = "Asia/Seoul";
+    my $rentable_duration = 30;
+    my $rented_duration   = 3;
+    my $rent_ratio        = 0.1;
+    ok my $clothes = Clothes->find( { code => $code } ) => "find clothes";
+    is $clothes->code, $code => "clothes.code";
+    is $clothes->rentable_duration( $system_start_date, $tz ),
+        $rentable_duration => "clothes.rentable_duration";
+    is $clothes->rented_duration, $rented_duration => "clothes.rented_duration";
+    is $clothes->rent_ratio( $system_start_date, $tz ),
+        $rent_ratio => "clothes.rent_ratio";
+};
+
+subtest "clothes.rent_ratio(): normal donation, immediately return", sub {
+    my $code              = "0J0H3";
+    my $tz                = "Asia/Seoul";
+    my $rentable_duration = 30;
+    my $rented_duration   = 1;
+    my $rent_ratio        = 0.0333333333333333;
+    ok my $clothes = Clothes->find( { code => $code } ) => "find clothes";
+    is $clothes->code, $code => "clothes.code";
+    is $clothes->rentable_duration( $system_start_date, $tz ),
+        $rentable_duration => "clothes.rentable_duration";
+    is $clothes->rented_duration, $rented_duration => "clothes.rented_duration";
+    is $clothes->rent_ratio( $system_start_date, $tz ),
+        $rent_ratio => "clothes.rent_ratio";
+};
+
+subtest "clothes.rent_ratio(): abnormal donation, normal return", sub {
+    my $code              = "0J0H4";
+    my $tz                = "Asia/Seoul";
+    my $rentable_duration = -8;
+    my $rented_duration   = 3;
+    my $rent_ratio        = -0.375;
+    ok my $clothes = Clothes->find( { code => $code } ) => "find clothes";
+    is $clothes->code, $code => "clothes.code";
+    is $clothes->rentable_duration( $system_start_date, $tz ),
+        $rentable_duration => "clothes.rentable_duration";
+    is $clothes->rented_duration, $rented_duration => "clothes.rented_duration";
+    is $clothes->rent_ratio( $system_start_date, $tz ),
+        $rent_ratio => "clothes.rent_ratio";
+};
+
+## Your testing code above ##
+
+done_testing;

--- a/t/gh-076-exception-for-rentable_duration.t
+++ b/t/gh-076-exception-for-rentable_duration.t
@@ -34,6 +34,13 @@ fixtures_ok(
     "Installed fixtures",
 );
 
+my $system_start_date = {
+    year      => 2014,
+    month     => 12,
+    day       => 17,
+    time_zone => 'Asia/Seoul',
+};
+
 ## Your testing code below ##
 
 subtest "clothes.warehousing_date(): after system start date", sub {
@@ -41,7 +48,7 @@ subtest "clothes.warehousing_date(): after system start date", sub {
     my $ymd  = "2015-03-15";
     ok my $clothes = Clothes->find( { code => $code } ) => "find clothes";
     is $clothes->code, $code => "clothes.code";
-    my $warehousing_date = $clothes->warehousing_date;
+    my $warehousing_date = $clothes->warehousing_date($system_start_date);
     is $warehousing_date->ymd, $ymd => "clothes.warehousing_date";
 };
 
@@ -50,7 +57,7 @@ subtest "clothes.warehousing_date(): before system start date", sub {
     my $ymd  = "2014-12-17";
     ok my $clothes = Clothes->find( { code => $code } ) => "find clothes";
     is $clothes->code, $code => "clothes.code";
-    my $warehousing_date = $clothes->warehousing_date;
+    my $warehousing_date = $clothes->warehousing_date($system_start_date);
     is $warehousing_date->ymd, $ymd => "clothes.warehousing_date";
 };
 
@@ -58,16 +65,18 @@ subtest "clothes.rentable_duration(): 1 month earlier than today", sub {
     my $code = "0J0H3";
     my $days = 30;
     ok my $clothes = Clothes->find( { code => $code } ) => "find clothes";
-    is $clothes->code,              $code => "clothes.code";
-    is $clothes->rentable_duration, $days => "clothes.rentable_duration";
+    is $clothes->code, $code => "clothes.code";
+    is $clothes->rentable_duration( $system_start_date, 'Asia/Seoul' ),
+        $days => "clothes.rentable_duration";
 };
 
 subtest "clothes.rentable_duration(): warehousing date is earlier than today", sub {
     my $code = "0J0H4";
     my $days = -8;
     ok my $clothes = Clothes->find( { code => $code } ) => "find clothes";
-    is $clothes->code,              $code => "clothes.code";
-    is $clothes->rentable_duration, $days => "clothes.rentable_duration";
+    is $clothes->code, $code => "clothes.code";
+    is $clothes->rentable_duration( $system_start_date, 'Asia/Seoul' ),
+        $days => "clothes.rentable_duration";
 };
 
 ## Your testing code above ##

--- a/t/gh-076-exception-for-rentable_duration.t
+++ b/t/gh-076-exception-for-rentable_duration.t
@@ -4,7 +4,14 @@ use strict;
 use warnings;
 use DateTime;
 
-my $now = DateTime->now( time_zone => "Asia/Seoul" );
+my $time_zone       = "Asia/Seoul";
+my $now_dt          = DateTime->now( time_zone => $time_zone );
+my $system_start_dt = DateTime->new(
+    year      => 2014,
+    month     => 12,
+    day       => 17,
+    time_zone => $time_zone,
+);
 
 use Test::DBIx::Class {
     schema_class => "OpenCloset::Schema",
@@ -20,8 +27,8 @@ fixtures_ok(
             [qw/id user_id create_date/],
             [ 1, 1, "2015-03-15 13:00:34" ],
             [ 2, 1, "2014-11-15 23:12:34" ],
-            [ 3, 1, $now->clone->add( days => -30 )->ymd ],
-            [ 4, 1, $now->clone->add( days => 8 )->ymd ],
+            [ 3, 1, $now_dt->clone->add( days => -30 )->ymd ],
+            [ 4, 1, $now_dt->clone->add( days => 8 )->ymd ],
         ],
         Clothes => [
             [qw/id code donation_id category/],
@@ -34,13 +41,6 @@ fixtures_ok(
     "Installed fixtures",
 );
 
-my $system_start_date = {
-    year      => 2014,
-    month     => 12,
-    day       => 17,
-    time_zone => 'Asia/Seoul',
-};
-
 ## Your testing code below ##
 
 subtest "clothes.warehousing_date(): after system start date", sub {
@@ -48,8 +48,8 @@ subtest "clothes.warehousing_date(): after system start date", sub {
     my $ymd  = "2015-03-15";
     ok my $clothes = Clothes->find( { code => $code } ) => "find clothes";
     is $clothes->code, $code => "clothes.code";
-    my $warehousing_date = $clothes->warehousing_date($system_start_date);
-    is $warehousing_date->ymd, $ymd => "clothes.warehousing_date";
+    my $warehousing_dt = $clothes->warehousing_date( $time_zone, $system_start_dt );
+    is $warehousing_dt->ymd, $ymd => "clothes.warehousing_date";
 };
 
 subtest "clothes.warehousing_date(): before system start date", sub {
@@ -57,8 +57,8 @@ subtest "clothes.warehousing_date(): before system start date", sub {
     my $ymd  = "2014-12-17";
     ok my $clothes = Clothes->find( { code => $code } ) => "find clothes";
     is $clothes->code, $code => "clothes.code";
-    my $warehousing_date = $clothes->warehousing_date($system_start_date);
-    is $warehousing_date->ymd, $ymd => "clothes.warehousing_date";
+    my $warehousing_dt = $clothes->warehousing_date( $time_zone, $system_start_dt );
+    is $warehousing_dt->ymd, $ymd => "clothes.warehousing_date";
 };
 
 subtest "clothes.rentable_duration(): 1 month earlier than today", sub {
@@ -66,7 +66,7 @@ subtest "clothes.rentable_duration(): 1 month earlier than today", sub {
     my $days = 30;
     ok my $clothes = Clothes->find( { code => $code } ) => "find clothes";
     is $clothes->code, $code => "clothes.code";
-    is $clothes->rentable_duration( $system_start_date, 'Asia/Seoul' ),
+    is $clothes->rentable_duration( $now_dt, $system_start_dt ),
         $days => "clothes.rentable_duration";
 };
 
@@ -75,7 +75,7 @@ subtest "clothes.rentable_duration(): warehousing date is earlier than today", s
     my $days = -8;
     ok my $clothes = Clothes->find( { code => $code } ) => "find clothes";
     is $clothes->code, $code => "clothes.code";
-    is $clothes->rentable_duration( $system_start_date, 'Asia/Seoul' ),
+    is $clothes->rentable_duration( $now_dt, $system_start_dt ),
         $days => "clothes.rentable_duration";
 };
 


### PR DESCRIPTION
하드코딩되어있던 기준시점의 정보를 인자로 처리하도록 수정했습니다.
- #74 를 해결하는 PR입니다.
- #75 , #76 과 충돌이 예상됩니다.
