### PR TITLE
create_date 와 update_date 의 잘못된 값을 바로잡음

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{ $dist->name }}
 
 {{ $NEXT }}
+    - Use `get_kst_timestamp` to get local timestamp (#117)
+    - Use 'Asia/Seoul' timezone at all datetime columns (#117)
 
 0.046     2017-02-09 09:06:25+09:00 Asia/Seoul
     - Add column: user_info.top_size (#114)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,6 +24,7 @@ my %WriteMakefileArgs = (
     "DBIx::Class::Schema" => 0,
     "DBIx::Class::Schema::Loader" => 0,
     "DBIx::Class::TimeStamp" => 0,
+    "DateTime" => 0,
     "SQL::Abstract" => 0,
     "base" => 0,
     "experimental" => 0,
@@ -33,7 +34,6 @@ my %WriteMakefileArgs = (
     "warnings" => 0
   },
   "TEST_REQUIRES" => {
-    "DateTime" => 0,
     "ExtUtils::MakeMaker" => 0,
     "File::Spec" => 0,
     "Test::DBIx::Class" => 0,

--- a/cpanfile
+++ b/cpanfile
@@ -6,6 +6,7 @@ requires "DBIx::Class::InflateColumn::DateTime" => "0";
 requires "DBIx::Class::Schema" => "0";
 requires "DBIx::Class::Schema::Loader" => "0";
 requires "DBIx::Class::TimeStamp" => "0";
+requires "DateTime" => "0";
 requires "SQL::Abstract" => "0";
 requires "base" => "0";
 requires "experimental" => "0";
@@ -16,7 +17,6 @@ requires "utf8" => "0";
 requires "warnings" => "0";
 
 on 'test' => sub {
-  requires "DateTime" => "0";
   requires "ExtUtils::MakeMaker" => "0";
   requires "File::Spec" => "0";
   requires "Test::DBIx::Class" => "0";

--- a/db/schema-loader.pl
+++ b/db/schema-loader.pl
@@ -73,28 +73,28 @@ my $CONF = OpenCloset::Config::load;
                 when ('create_date') {
                     return +{
                         %$col_info,
-                        set_on_create    => 1,
-                        inflate_datetime => 1,
+                        dynamic_default_on_create => 'get_kst_timestamp',
+                        timezone => $CONF->{timezone},
                     };
                 }
                 when ('update_date') {
                     return +{
                         %$col_info,
-                        set_on_create    => 1,
-                        set_on_update    => 1,
-                        inflate_datetime => 1,
+                        dynamic_default_on_create => 'get_kst_timestamp',
+                        dynamic_default_on_update => 'get_kst_timestamp',
+                        timezone => $CONF->{timezone},
                     };
                 }
                 when (/_date$/) {
                     return +{
                         %$col_info,
-                        inflate_datetime => 1,
+                        timezone => $CONF->{timezone},
                     };
                 }
                 when ('date') {
                     return +{
                         %$col_info,
-                        inflate_datetime => 1,
+                        timezone => $CONF->{timezone},
                     };
                 }
                 when ('password') {
@@ -109,7 +109,7 @@ my $CONF = OpenCloset::Config::load;
                 when ('timestamp') {
                     return +{
                         %$col_info,
-                        inflate_datetime => 1,
+                        timezone => $CONF->{timezone},
                     };
                 }
             }

--- a/lib/OpenCloset/Schema/Base.pm
+++ b/lib/OpenCloset/Schema/Base.pm
@@ -3,6 +3,7 @@ package OpenCloset::Schema::Base;
 
 use strict;
 use warnings;
+use DateTime;
 
 our $VERSION = '0.047';
 
@@ -33,6 +34,12 @@ use overload '""' => sub {
 
     return "$out$line";
 };
+
+=head2 get_kst_timestamp
+
+=cut
+
+sub get_kst_timestamp { DateTime->now( time_zone => 'Asia/Seoul' ) }
 
 1;
 

--- a/lib/OpenCloset/Schema/Result/Booking.pm
+++ b/lib/OpenCloset/Schema/Result/Booking.pm
@@ -40,8 +40,8 @@ __PACKAGE__->table("booking");
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 0
+  timezone: 'Asia/Seoul'
 
 =head2 gender
 
@@ -71,8 +71,8 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 0,
+        timezone                  => "Asia/Seoul",
     },
     "gender",
     { data_type => "varchar", is_nullable => 0, size => 6 },
@@ -128,8 +128,8 @@ __PACKAGE__->has_many(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2015-08-13 18:42:58
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:dT/QG5IrnLhLpA5tBgGHYw
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:4EnPGX+p9kCNcEOH39xrYg
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 

--- a/lib/OpenCloset/Schema/Result/Coupon.pm
+++ b/lib/OpenCloset/Schema/Result/Coupon.pm
@@ -74,25 +74,25 @@ provided|used|discarded
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =head2 update_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
+  dynamic_default_on_update: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
-  set_on_update: 1
+  timezone: 'Asia/Seoul'
 
 =head2 expires_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 1
+  timezone: 'Asia/Seoul'
 
 =cut
 
@@ -123,25 +123,25 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
     "update_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
+        dynamic_default_on_update => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
-        set_on_update             => 1,
+        timezone                  => "Asia/Seoul",
     },
     "expires_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 1,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -191,8 +191,8 @@ __PACKAGE__->has_many(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2016-03-11 17:32:55
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:OMsO7mCFqrioC+Alg5RlpQ
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:34
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:SyxgfJ1RBhzDzeWMM3cKsQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/OpenCloset/Schema/Result/DiscardClothes.pm
+++ b/lib/OpenCloset/Schema/Result/DiscardClothes.pm
@@ -58,18 +58,18 @@ __PACKAGE__->table("discard_clothes");
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =head2 update_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
+  dynamic_default_on_update: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
-  set_on_update: 1
+  timezone: 'Asia/Seoul'
 
 =cut
 
@@ -91,18 +91,18 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
     "update_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
+        dynamic_default_on_update => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
-        set_on_update             => 1,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -152,8 +152,8 @@ __PACKAGE__->belongs_to(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07045 @ 2016-05-18 10:49:40
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:NE3WEhQBw++RSFP5sZdvSw
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:34
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Hnp1v1xEJwdRAGnVsb2NHA
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/OpenCloset/Schema/Result/Donation.pm
+++ b/lib/OpenCloset/Schema/Result/Donation.pm
@@ -52,9 +52,9 @@ __PACKAGE__->table("donation");
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =cut
 
@@ -79,9 +79,9 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -145,8 +145,8 @@ __PACKAGE__->belongs_to(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2016-04-01 15:13:11
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:jlWrjy7dBcwApLAEnw2Itw
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:34
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:YAzsxVt7G3X1pN0lDeexMA
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 

--- a/lib/OpenCloset/Schema/Result/DonationForm.pm
+++ b/lib/OpenCloset/Schema/Result/DonationForm.pm
@@ -67,8 +67,8 @@ __PACKAGE__->table("donation_form");
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 1
+  timezone: 'Asia/Seoul'
 
 =head2 gender
 
@@ -186,25 +186,25 @@ flag to show each sms sent or not
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =head2 return_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 1
+  timezone: 'Asia/Seoul'
 
 =head2 update_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
+  dynamic_default_on_update: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
-  set_on_update: 1
+  timezone: 'Asia/Seoul'
 
 =cut
 
@@ -233,8 +233,8 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 1,
+        timezone                  => "Asia/Seoul",
     },
     "gender",
     { data_type => "integer", is_nullable => 1 },
@@ -274,25 +274,25 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
     "return_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 1,
+        timezone                  => "Asia/Seoul",
     },
     "update_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
+        dynamic_default_on_update => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
-        set_on_update             => 1,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -333,8 +333,8 @@ __PACKAGE__->belongs_to(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2016-04-01 15:13:12
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:nQ2tB09xZTWrOe5bTzjt3Q
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:34
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:+eKO8UidXzbQMlUYRyH6dw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/OpenCloset/Schema/Result/Order.pm
+++ b/lib/OpenCloset/Schema/Result/Order.pm
@@ -104,36 +104,36 @@ __PACKAGE__->table("order");
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 1
+  timezone: 'Asia/Seoul'
 
 =head2 wearon_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 1
+  timezone: 'Asia/Seoul'
 
 =head2 target_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 1
+  timezone: 'Asia/Seoul'
 
 =head2 user_target_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 1
+  timezone: 'Asia/Seoul'
 
 =head2 return_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 1
+  timezone: 'Asia/Seoul'
 
 =head2 return_method
 
@@ -313,18 +313,18 @@ null and 0 are false, otherwise true
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =head2 update_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
+  dynamic_default_on_update: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
-  set_on_update: 1
+  timezone: 'Asia/Seoul'
 
 =head2 does_wear
 
@@ -405,36 +405,36 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 1,
+        timezone                  => "Asia/Seoul",
     },
     "wearon_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 1,
+        timezone                  => "Asia/Seoul",
     },
     "target_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 1,
+        timezone                  => "Asia/Seoul",
     },
     "user_target_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 1,
+        timezone                  => "Asia/Seoul",
     },
     "return_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 1,
+        timezone                  => "Asia/Seoul",
     },
     "return_method",
     { data_type => "varchar", is_nullable => 1, size => 32 },
@@ -504,18 +504,18 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
     "update_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
+        dynamic_default_on_update => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
-        set_on_update             => 1,
+        timezone                  => "Asia/Seoul",
     },
     "does_wear",
     { data_type => "integer", is_nullable => 1 },
@@ -755,8 +755,8 @@ __PACKAGE__->belongs_to(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-02-06 17:30:11
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ePWCbOnVZQKBufbqROn4Kw
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:35
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:HufQghNbeA9fMwX3JO9K8Q
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 

--- a/lib/OpenCloset/Schema/Result/OrderDetail.pm
+++ b/lib/OpenCloset/Schema/Result/OrderDetail.pm
@@ -95,9 +95,9 @@ __PACKAGE__->table("order_detail");
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =cut
 
@@ -141,9 +141,9 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -219,8 +219,8 @@ __PACKAGE__->belongs_to(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07045 @ 2016-04-27 15:53:19
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:NcNY1dRLU0nD7SezZVqgHw
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:35
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:p0mkI7OZGC3b3xCi2nVsJg
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 

--- a/lib/OpenCloset/Schema/Result/OrderParcel.pm
+++ b/lib/OpenCloset/Schema/Result/OrderParcel.pm
@@ -85,25 +85,25 @@ flag to show each sms sent or not
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =head2 update_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
+  dynamic_default_on_update: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
-  set_on_update: 1
+  timezone: 'Asia/Seoul'
 
 =head2 sent_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 1
+  timezone: 'Asia/Seoul'
 
 ??????
 
@@ -111,8 +111,8 @@ flag to show each sms sent or not
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 1
+  timezone: 'Asia/Seoul'
 
 ??????
 
@@ -120,8 +120,8 @@ flag to show each sms sent or not
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 1
+  timezone: 'Asia/Seoul'
 
 ??????
 
@@ -129,8 +129,8 @@ flag to show each sms sent or not
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 1
+  timezone: 'Asia/Seoul'
 
 ??????
 
@@ -172,46 +172,46 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
     "update_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
+        dynamic_default_on_update => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
-        set_on_update             => 1,
+        timezone                  => "Asia/Seoul",
     },
     "sent_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 1,
+        timezone                  => "Asia/Seoul",
     },
     "arrival_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 1,
+        timezone                  => "Asia/Seoul",
     },
     "return_sent_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 1,
+        timezone                  => "Asia/Seoul",
     },
     "return_arrival_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 1,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -276,8 +276,8 @@ __PACKAGE__->belongs_to(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07045 @ 2016-09-21 14:13:45
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Fv5mcGzHbhm/8c0WyXQ1xA
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:35
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:jdS1YvNdJPBmenhi2ZVH1g
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/OpenCloset/Schema/Result/OrderSale.pm
+++ b/lib/OpenCloset/Schema/Result/OrderSale.pm
@@ -54,18 +54,18 @@ __PACKAGE__->table("order_sale");
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =head2 update_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
+  dynamic_default_on_update: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
-  set_on_update: 1
+  timezone: 'Asia/Seoul'
 
 =cut
 
@@ -95,18 +95,18 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
     "update_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
+        dynamic_default_on_update => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
-        set_on_update             => 1,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -157,8 +157,8 @@ __PACKAGE__->belongs_to(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07046 @ 2016-10-17 16:59:40
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:uunFecEuG2fLp01xPDq0Qw
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:uFY00FeVXz4fYcaPIe4fWg
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 

--- a/lib/OpenCloset/Schema/Result/OrderSizeLog.pm
+++ b/lib/OpenCloset/Schema/Result/OrderSizeLog.pm
@@ -52,8 +52,8 @@ __PACKAGE__->table("order_size_log");
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 0
+  timezone: 'Asia/Seoul'
 
 =head2 category
 
@@ -155,8 +155,8 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 0,
+        timezone                  => "Asia/Seoul",
     },
     "category",
     { data_type => "varchar", is_nullable => 0, size => 32 },
@@ -196,8 +196,8 @@ __PACKAGE__->add_columns(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2016-04-21 14:05:42
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:LRAYo8epKaXHnj4i5OiNFw
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:5kmnxPMCEhG8+2RAFLr2cA
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/OpenCloset/Schema/Result/OrderStatusLog.pm
+++ b/lib/OpenCloset/Schema/Result/OrderStatusLog.pm
@@ -47,8 +47,8 @@ __PACKAGE__->table("order_status_log");
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 0
+  timezone: 'Asia/Seoul'
 
 =cut
 
@@ -71,8 +71,8 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 0,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -111,8 +111,8 @@ __PACKAGE__->belongs_to(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2015-08-13 18:42:59
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:1ZX6srVQYeevUn6fRYHa9w
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:GLmZiB/VWykLb35rCJEnHg
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 

--- a/lib/OpenCloset/Schema/Result/Payment.pm
+++ b/lib/OpenCloset/Schema/Result/Payment.pm
@@ -81,18 +81,18 @@ client id: merchant_uid
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =head2 update_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
+  dynamic_default_on_update: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
-  set_on_update: 1
+  timezone: 'Asia/Seoul'
 
 =cut
 
@@ -125,18 +125,18 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
     "update_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
+        dynamic_default_on_update => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
-        set_on_update             => 1,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -211,8 +211,8 @@ __PACKAGE__->has_many(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-01-25 17:43:09
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:JoGCYlKhcwxep3S4nAFqpw
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:usTO+uJC5LRfW7wHgZJWyg
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/OpenCloset/Schema/Result/PaymentLog.pm
+++ b/lib/OpenCloset/Schema/Result/PaymentLog.pm
@@ -60,9 +60,9 @@ paid|ready|cancelled|failed
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =cut
 
@@ -89,9 +89,9 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -127,8 +127,8 @@ __PACKAGE__->belongs_to(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07046 @ 2017-01-24 15:36:58
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:+KswfElkGZ+7TBdMm10TTQ
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:37
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:3btOOBsqrkW8sgWGKvxLoA
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/OpenCloset/Schema/Result/RepairClothes.pm
+++ b/lib/OpenCloset/Schema/Result/RepairClothes.pm
@@ -71,8 +71,8 @@ __PACKAGE__->table("repair_clothes");
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 1
+  timezone: 'Asia/Seoul'
 
 ?????
 
@@ -80,8 +80,8 @@ __PACKAGE__->table("repair_clothes");
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 1
+  timezone: 'Asia/Seoul'
 
 ???
 
@@ -89,18 +89,18 @@ __PACKAGE__->table("repair_clothes");
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =head2 update_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
+  dynamic_default_on_update: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
-  set_on_update: 1
+  timezone: 'Asia/Seoul'
 
 =cut
 
@@ -126,32 +126,32 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 1,
+        timezone                  => "Asia/Seoul",
     },
     "pickup_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 1,
+        timezone                  => "Asia/Seoul",
     },
     "create_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
     "update_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
+        dynamic_default_on_update => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
-        set_on_update             => 1,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -201,8 +201,8 @@ __PACKAGE__->belongs_to(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07045 @ 2016-05-10 14:51:21
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:/HTUd6iGvK2RJYaVz5o3HQ
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:37
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:oNsbZ2kFWZuU0BrvteiC9Q
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/OpenCloset/Schema/Result/SMS.pm
+++ b/lib/OpenCloset/Schema/Result/SMS.pm
@@ -80,16 +80,16 @@ __PACKAGE__->table("sms");
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 1
+  timezone: 'Asia/Seoul'
 
 =head2 create_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =cut
 
@@ -124,16 +124,16 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 1,
+        timezone                  => "Asia/Seoul",
     },
     "create_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -152,8 +152,8 @@ __PACKAGE__->set_primary_key("id");
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2015-08-13 18:43:00
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:qxKvVGIimPd2miAOOU8gWQ
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:37
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:XMPV3CNNUk7pir87t8ppkw
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 

--- a/lib/OpenCloset/Schema/Result/Sale.pm
+++ b/lib/OpenCloset/Schema/Result/Sale.pm
@@ -51,18 +51,18 @@ __PACKAGE__->table("sale");
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =head2 update_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
+  dynamic_default_on_update: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
-  set_on_update: 1
+  timezone: 'Asia/Seoul'
 
 =cut
 
@@ -82,18 +82,18 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
     "update_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
+        dynamic_default_on_update => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
-        set_on_update             => 1,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -141,8 +141,8 @@ __PACKAGE__->has_many(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07046 @ 2016-10-17 16:59:41
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:S69JNXO5nuGGiDS+4Xmgkg
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:37
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:1m3lNvZBddKkkVLIyJeIjg
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 

--- a/lib/OpenCloset/Schema/Result/Satisfaction.pm
+++ b/lib/OpenCloset/Schema/Result/Satisfaction.pm
@@ -72,9 +72,9 @@ __PACKAGE__->table("satisfaction");
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =cut
 
@@ -102,9 +102,9 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -157,8 +157,8 @@ __PACKAGE__->belongs_to(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2015-08-13 18:42:59
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:+7i6ey+0MHPq0fs36M0BWA
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:37
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:eK/bguDSpNcG+jpN3k5ZgA
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 

--- a/lib/OpenCloset/Schema/Result/SmsMacro.pm
+++ b/lib/OpenCloset/Schema/Result/SmsMacro.pm
@@ -65,18 +65,18 @@ __PACKAGE__->table("sms_macro");
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =head2 update_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
+  dynamic_default_on_update: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
-  set_on_update: 1
+  timezone: 'Asia/Seoul'
 
 =cut
 
@@ -100,18 +100,18 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
     "update_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
+        dynamic_default_on_update => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
-        set_on_update             => 1,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -130,8 +130,8 @@ __PACKAGE__->set_primary_key("id");
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07045 @ 2016-11-17 15:44:17
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:lzm5faT0o7RfmxHrdJ1OXA
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:38
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:J4lcZiebyTeHjFobALzV5Q
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/OpenCloset/Schema/Result/User.pm
+++ b/lib/OpenCloset/Schema/Result/User.pm
@@ -87,18 +87,18 @@ first 40 length for digest, after 10 length for salt(random)
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =head2 update_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
+  dynamic_default_on_update: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
-  set_on_update: 1
+  timezone: 'Asia/Seoul'
 
 =cut
 
@@ -132,18 +132,18 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
     "update_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
+        dynamic_default_on_update => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
-        set_on_update             => 1,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -264,8 +264,8 @@ __PACKAGE__->might_have(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-01-12 18:42:25
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Qi+mahJehcjxZ/zpWRTdvA
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:39
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Q56UzKcNRX2kBOI0OZg+bg
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 

--- a/lib/OpenCloset/Schema/Result/UserAddress.pm
+++ b/lib/OpenCloset/Schema/Result/UserAddress.pm
@@ -91,18 +91,18 @@ dbid
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =head2 update_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
+  dynamic_default_on_update: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
-  set_on_update: 1
+  timezone: 'Asia/Seoul'
 
 =cut
 
@@ -137,18 +137,18 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
     "update_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
+        dynamic_default_on_update => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
-        set_on_update             => 1,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -199,8 +199,8 @@ __PACKAGE__->belongs_to(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-02-06 14:31:48
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:QfsvUERGSPESd/SkurR8xQ
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:39
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:mBHlB7ezb+l/XtQw8Yac4w
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/OpenCloset/Schema/Result/UserInfo.pm
+++ b/lib/OpenCloset/Schema/Result/UserInfo.pm
@@ -204,8 +204,8 @@ male/female
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 1
+  timezone: 'Asia/Seoul'
 
 =head2 purpose
 
@@ -305,8 +305,8 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 1,
+        timezone                  => "Asia/Seoul",
     },
     "purpose",
     { data_type => "varchar", is_nullable => 1, size => 128 },
@@ -376,8 +376,8 @@ __PACKAGE__->belongs_to(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-02-09 09:00:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:aYREv9PuX0Cl2nQHjhB8Fw
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:39
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:J1MxMoZDEfBQljEf3vTlfQ
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 

--- a/lib/OpenCloset/Schema/Result/Volunteer.pm
+++ b/lib/OpenCloset/Schema/Result/Volunteer.pm
@@ -71,16 +71,16 @@ regex: 01d{8,9}
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 1
+  timezone: 'Asia/Seoul'
 
 =head2 create_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =cut
 
@@ -106,16 +106,16 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 1,
+        timezone                  => "Asia/Seoul",
     },
     "create_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -177,8 +177,8 @@ __PACKAGE__->has_many(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2015-10-15 19:08:08
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:vPwobkhF3XC8b8aULjRgkg
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:39
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:gr+24eZh1kKCQYLanP4lUA
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/OpenCloset/Schema/Result/VolunteerGuestbook.pm
+++ b/lib/OpenCloset/Schema/Result/VolunteerGuestbook.pm
@@ -86,9 +86,9 @@ __PACKAGE__->table("volunteer_guestbook");
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =cut
 
@@ -125,9 +125,9 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -163,8 +163,8 @@ __PACKAGE__->belongs_to(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2015-09-01 18:36:02
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:PmyUxxryFYPOAteRkiNKJQ
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:39
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:1AC8oI5btGRubmAKBt34Eg
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/OpenCloset/Schema/Result/VolunteerWork.pm
+++ b/lib/OpenCloset/Schema/Result/VolunteerWork.pm
@@ -47,15 +47,15 @@ __PACKAGE__->table("volunteer_work");
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 0
+  timezone: 'Asia/Seoul'
 
 =head2 activity_to_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
   is_nullable: 0
+  timezone: 'Asia/Seoul'
 
 =head2 period
 
@@ -145,9 +145,9 @@ volunteer organization(1365) username
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
-  inflate_datetime: 1
+  dynamic_default_on_create: 'get_kst_timestamp'
   is_nullable: 1
-  set_on_create: 1
+  timezone: 'Asia/Seoul'
 
 =cut
 
@@ -170,15 +170,15 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 0,
+        timezone                  => "Asia/Seoul",
     },
     "activity_to_date",
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
         is_nullable               => 0,
+        timezone                  => "Asia/Seoul",
     },
     "period",
     { data_type => "varchar", is_nullable => 1, size => 32 },
@@ -217,9 +217,9 @@ __PACKAGE__->add_columns(
     {
         data_type                 => "datetime",
         datetime_undef_if_invalid => 1,
-        inflate_datetime          => 1,
+        dynamic_default_on_create => "get_kst_timestamp",
         is_nullable               => 1,
-        set_on_create             => 1,
+        timezone                  => "Asia/Seoul",
     },
 );
 
@@ -270,8 +270,8 @@ __PACKAGE__->has_many(
 #>>>
 
 
-# Created by DBIx::Class::Schema::Loader v0.07045 @ 2016-11-25 11:48:08
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:De05FjTb6nY3tzZZKNIE9w
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-03-13 15:48:40
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:qKVWEB8hSotSSsGE3XnVlQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/t/01-set-on-create.t
+++ b/t/01-set-on-create.t
@@ -2,6 +2,7 @@ use Test::More;
 
 use strict;
 use warnings;
+use DateTime;
 
 use Test::DBIx::Class {
     schema_class => 'OpenCloset::Schema',
@@ -13,9 +14,15 @@ use Test::DBIx::Class {
 
 ## Your testing code below ##
 
+my $tz = 'Asia/Seoul';
+my $now = DateTime->now( time_zone => $tz );
+
 ok my $order = Order->create( { status_id => 14, user_id => 2 } ), 'Order created';
 ok $order->create_date, 'create_date is not null';
 ok $order->update_date, 'update_date is not null';
+is( $order->create_date->time_zone->name, $tz,         'timezone' );
+is( $order->update_date->time_zone->name, $tz,         'timezone' );
+is( $order->create_date->epoch,           $now->epoch, 'epoch' );
 
 ## Your testing code above ##
 


### PR DESCRIPTION
#117 

``` perl
my $order = $schema->create('...');
say $order->create_date->datetime;
say $order->create_date->time_zone;
say $order->create_date->offset;

__DATA__
2017-03-13T15:29:00
DateTime::TimeZone::Asia::Seoul=HASH(0x699d700)
32400
```

이 패치가 적용되면 넣고 업데이트 되는거는 원래 자동이었고,
빼서 쓸때에 모든 datetime object(`$obj->*_date`) 는 `Asia/Seoul` 의 time zone 을 가집니다.